### PR TITLE
Fix reference to saturated model

### DIFF
--- a/docs/src/GLM.md
+++ b/docs/src/GLM.md
@@ -43,7 +43,7 @@ This result is a little bit different from [`GLM.ftest`](https://juliastats.org/
 ```@example glm
 ftest(getproperty.(lms[2:end], :model)...)
 ```
-In `anova`, the F value is calculated by dividing [MSR](https://en.wikipedia.org/wiki/Mean_squared_error) (mean of ΔDeviance) with mean of [RSS](https://en.wikipedia.org/wiki/Residual_sum_of_squares) of saturated model just like [`anova` in R](https://www.rdocumentation.org/packages/stats/versions/3.6.2/topics/anova), while in [`GLM.ftest`](https://juliastats.org/GLM.jl/stable/api/#GLM.ftest), the denominator is replaced by [RSS](https://en.wikipedia.org/wiki/Residual_sum_of_squares) of subsequant model.
+In `anova`, the F value is calculated by dividing [MSR](https://en.wikipedia.org/wiki/Mean_squared_error) (mean of ΔDeviance) with mean of [RSS](https://en.wikipedia.org/wiki/Residual_sum_of_squares) of the most complex model just like [`anova` in R](https://www.rdocumentation.org/packages/stats/versions/3.6.2/topics/anova), while in [`GLM.ftest`](https://juliastats.org/GLM.jl/stable/api/#GLM.ftest), the denominator is replaced by [RSS](https://en.wikipedia.org/wiki/Residual_sum_of_squares) of subsequent model.
 ## Generalized linear models 
 ```julia
 quine = dataset("MASS", "quine")


### PR DESCRIPTION
It seems to me that R's `anova` takes as reference the most complex model rather than the saturated model. Indeed, dropping the most complex model from the call changes p-values. Position of the most complex model does not have any effect.